### PR TITLE
fix: use `/health` instead of `/health_check` and add `curl`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-RUN apk add --no-cache su-exec
+RUN apk add --no-cache su-exec curl
 RUN addgroup -S app && adduser -S app -G app
 
 COPY . .

--- a/main.py
+++ b/main.py
@@ -37,8 +37,8 @@ def _latest_state_path(project: str, state_name: str) -> str:
 def _versioned_state_path(project: str, state_name: str, version: int) -> str:
     return os.path.join(_state_dir(project, state_name), f"{version}.tfstate")
 
-@app.get("/health_check")
-async def health_check() -> dict:
+@app.get("/health")
+async def health() -> dict:
     """
     Health check endpoint.
     """


### PR DESCRIPTION
This is the most common endpoint and more generic. Also `curl` is added in order to perform the health check with Docker Compose.